### PR TITLE
Fix functional tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,7 +68,7 @@ jobs:
       - unit-test
       - build
     name: Functional tests
-    runs-on: [self-hosted, linux, amd64, noble]
+    runs-on: [self-hosted, linux, amd64, xlarge]
     steps:
 
       - name: Download charm

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python3 -m pip install tox
+          sudo apt install tox
           if [ ! -d "$HOME/.local/share/juju" ]; then
             sudo snap install juju --channel=3.4/stable
             mkdir -p ~/.local/share/juju

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,7 +68,7 @@ jobs:
       - unit-test
       - build
     name: Functional tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, amd64, noble]
     steps:
 
       - name: Download charm

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt install tox
+          sudo apt install -y tox
           if [ ! -d "$HOME/.local/share/juju" ]; then
             sudo snap install juju --channel=3.4/stable
             mkdir -p ~/.local/share/juju

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -48,3 +48,4 @@ pyopenssl<=22.0.0
 
 pydantic < 2
 cosl
+tenacity

--- a/tests/bundles/noble-caracal.yaml
+++ b/tests/bundles/noble-caracal.yaml
@@ -1,13 +1,26 @@
 series: &series noble
 
+machines:
+  '0':
+  '1':
+  '2':
+  '3':
+  '4':
+  '5':
+    constraints: cores=2 mem=6G root-disk=40G virt-type=virtual-machine
+
 applications:
-  microceph:
-    charm: ch:microceph
+  ceph-mon:
+    charm: ch:ceph-mon
     num_units: 3
     channel: latest/edge
     options:
-      snap-channel: reef/stable
-    series: jammy
+      expected-osd-count: 1
+      monitor-count: 3
+    to:
+      - '0'
+      - '1'
+      - '2'
 
   ceph-nvme:
     charm: ../../ceph-nvme.charm
@@ -15,7 +28,20 @@ applications:
     options:
       nr-hugepages: 0
       cpuset: "2"
+    to:
+      - '3'
+      - '4'
+
+  ceph-osd:
+    charm: ch:ceph-osd
+    num_units: 1
+    channel: latest/edge
+    to:
+      - '5'
 
 relations:
-  - - 'microceph'
+  - - 'ceph-mon'
     - 'ceph-nvme'
+
+  - - 'ceph-osd:mon'
+    - 'ceph-mon:osd'

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -5,10 +5,10 @@ tests:
   - tests.target.CephNVMETest
 
 target_deploy_status:
-  ubuntu:
-    workload-status: active
-    workload-status-message-prefix: ''
+  ceph-osd:
+    workload-status: blocked
+    workload-status-message: 'No block devices detected using current configuration'
 
-  microceph:
-    workload-status: active
-    workload-status-message-prefix: ''
+  ceph-mon:
+    workload-status: waiting
+    workload-status-message: 'Monitor bootstrapped but waiting for number of OSDs to reach expected-osd-count (1)'

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,7 @@ deps = -r{toxinidir}/requirements.txt
 
 [testenv:pep8]
 basepython = python3
-deps = flake8==3.9.2
+deps = flake8
        charm-tools
 commands = flake8 {posargs} unit_tests files src tests
 


### PR DESCRIPTION
This patchset modifies the test bundle so that instead of microceph, it uses the ceph-mon and ceph-osd charms. It does this for 2 reasons:

First, to work around a transient bug in microceph where keys that are handled to clients aren't immediately usable. This can be worked around by introducing timeouts, but it's shaky and so it was decided to use a different set of charms.

Secondly, since the ceph-osd charm needs to be a virtual machine and it supports noble, it allows us to fully test the Linux kernel NVMe-oF driver to connect to the charm's endpoints.